### PR TITLE
Fix an issue binding this to events.emit

### DIFF
--- a/lib/platform_glfw.js
+++ b/lib/platform_glfw.js
@@ -27,7 +27,7 @@ module.exports = function () {
                 platform.width = evt.width;
                 platform.height = evt.height;
               }
-              _emit.apply(this, args);
+              _emit.apply(events, args);
             };
             return events;
         }


### PR DESCRIPTION
Small fix for node-webgl's `EventEmitter.emit` wrapper; it was binding the [global object](https://github.com/floored/node-glfw/blob/master/src/glfw.cc#L127) to `this` rather than the `events` object it seemed to want.

@juanandresfloored @judyhe 

It looks like this was fixed in the [main repo](https://github.com/mikeseven/node-webgl/blob/master/lib/platform_glfw.js#L29) as well (in a slightly different way), so we could also try to rebase on that! This seems to work as a temporary fix at least.
